### PR TITLE
(PC-4517) Adapt to introduction of "pcapi" Python package in pass-culture-api

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,10 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install -r requirements.txt;
+            pip install -e .
             python -m nltk.downloader punkt stopwords;
-            python install_database_extensions.py;
-            PYTHONPATH=. alembic upgrade head;
+            python -m pcapi.install_database_extensions
+            alembic upgrade head
       - run:
           name: Running tests
           command: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,9 +28,10 @@ services:
                git clone https://github.com/betagouv/pass-culture-api.git;
                cd pass-culture-api;
                pip install -r requirements.txt;
+               pip install -e .;
                python -m nltk.downloader punkt stopwords;
-               python install_database_extensions.py
-               PYTHONPATH=. alembic upgrade head
+               python -m pcapi.install_database_extensions;
+               alembic upgrade head;
                "
     env_file:
       - env_file


### PR DESCRIPTION
The code in the pass-culture-api repository has been moved to a
"pcapi" Python package. Path must be adapted. As a nice side-effect,
we don't need to override PYTHONPATH anymore.